### PR TITLE
add TogglInit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Wrapper around [watercooler-labs/toggl-cli](https://github.com/watercooler-labs/
 | `:TogglAuth` | Authenticate with Toggl. Not required if `TOGGL_API_TOKEN` is set |
 | `:TogglConfig` | Edit the configuration file |
 | `:TogglCurrent` | Show the current time entry |
+| `:TogglInit` | Initialize configuration file |
 | `:TogglStart <description>` | Start a new time entry with the given description |
 | `:TogglStop` | Stop the current time entry |
 


### PR DESCRIPTION
Provide `TogglInit` command when there is no active workspace. Then `TogglConfig` can be used to configure the workspace. 